### PR TITLE
Made the print compatible with Python 2.

### DIFF
--- a/l0_attack.py
+++ b/l0_attack.py
@@ -4,6 +4,7 @@
 ##
 ## This program is licenced under the BSD 2-Clause licence,
 ## contained in the LICENCE file in this directory.
+from __future__ import print_function
 
 import sys
 import tensorflow as tf


### PR DESCRIPTION
Python 2.7 would run this line into problem without the future print fuction:

print(step,*sess.run((loss1,loss2),feed_dict=feed_dict))