### PR TITLE
Modified prev init value to avoid early breaking

### DIFF
--- a/l2_attack.py
+++ b/l2_attack.py
@@ -188,7 +188,7 @@ class CarliniL2:
                                        self.assign_tlab: batchlab,
                                        self.assign_const: CONST})
             
-            prev = 1e6
+            prev = np.inf
             for iteration in range(self.MAX_ITERATIONS):
                 # perform the attack 
                 _, l, l2s, scores, nimg = self.sess.run([self.train, self.loss, 


### PR DESCRIPTION
Modified the init value for pred (loss) that is used in early abort to avoid early breaking when batch size is large, as losses are summed over the samples.